### PR TITLE
docs: Codify GitHub-first Program Controller operating mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ It is not a runtime capability layer. It is the project-of-projects control repo
 | [Roadmap](docs/IEF_ROADMAP.md) | v0 milestones: Setup → Core Loop → Protocol → Hardening |
 | [Startup Plan](docs/IEF_STARTUP_PLAN.md) | Bootstrap sequence and dependency order |
 | [Agent Rules](docs/IEF_AGENT_RULES.md) | AI agent working rules across repos |
+| [Program Controller Mode](docs/IEF_PROGRAM_CONTROLLER_MODE.md) | GitHub-first control plane, roles, L1/L2/L3 boundaries, SYNC_FROM_GITHUB |
 | [GitHub Workflow](docs/IEF_GITHUB_WORKFLOW.md) | Issue → PR → review → merge flow |
 | [Status Report](docs/IEF_STATUS_REPORT.md) | Current status of each repo |
 | [Definition of Done](docs/IEF_DEFINITION_OF_DONE.md) | Acceptance criteria per governance profile |

--- a/docs/IEF_GITHUB_WORKFLOW.md
+++ b/docs/IEF_GITHUB_WORKFLOW.md
@@ -25,11 +25,11 @@ All IEF agents operate under the **GitHub-first control plane** defined in [`IEF
 - GitHub issues, PRs, and comments are the durable source of truth. Chat history is ephemeral and must not be treated as authoritative.
 - Local agents (Qoder, Codex App/IDE, Claude Code, Gemini CLI, Antigravity, OpenClaw/Hermes-style agents) must run in `SYNC_FROM_GITHUB` mode.
 - Agents only modify files when a GitHub issue or PR comment explicitly requires action. Status/waiting/blocked comments do not authorize file changes.
-- Agents must not self-merge, self-close issues, or modify sibling repos.
+- Repo Worker Agents must not self-merge, self-close issues, or modify sibling repos. Program Controller may perform scoped L3 capability-repo changes only when a GitHub directive defines the target repo, scope, target files, and expected output under the Human Owner Standing Delegation.
 
 **SYNC_FROM_GITHUB startup sequence:**
 1. Read target issue body and **comment stream** for the current repo.
-2. Read related PR bodies and **comment streams**.
+2. Read related PR bodies and **comment streams** (including non-review PR comments on the target PR).
 3. Read latest Program Controller / Program Agent comments on the program epic.
 4. Read Codex review threads on the target PR.
 5. Read PR body and changed files.

--- a/docs/IEF_GITHUB_WORKFLOW.md
+++ b/docs/IEF_GITHUB_WORKFLOW.md
@@ -17,6 +17,24 @@ Issue created
   -> Issue closed
 ```
 
+## Agent Operating Mode
+
+All IEF agents operate under the **GitHub-first control plane** defined in [`IEF_PROGRAM_CONTROLLER_MODE.md`](IEF_PROGRAM_CONTROLLER_MODE.md).
+
+**Key rules:**
+- GitHub issues, PRs, and comments are the durable source of truth. Chat history is ephemeral and must not be treated as authoritative.
+- Local agents (Qoder, Codex App/IDE, Claude Code, Gemini CLI, Antigravity, OpenClaw/Hermes-style agents) must run in `SYNC_FROM_GITHUB` mode.
+- Agents only modify files when a GitHub issue or PR comment explicitly requires action. Status/waiting/blocked comments do not authorize file changes.
+- Agents must not self-merge, self-close issues, or modify sibling repos.
+
+**SYNC_FROM_GITHUB startup sequence:**
+1. Read target issue for the current repo.
+2. Read related PRs.
+3. Read latest Program Controller / Program Agent comments on the program epic.
+4. Read Codex review threads on the target PR.
+5. Read PR body and changed files.
+6. Read main branch docs / schemas / templates.
+
 ## Step 1 — Issue Creation
 
 Every official task must start as a GitHub issue.

--- a/docs/IEF_GITHUB_WORKFLOW.md
+++ b/docs/IEF_GITHUB_WORKFLOW.md
@@ -28,8 +28,8 @@ All IEF agents operate under the **GitHub-first control plane** defined in [`IEF
 - Agents must not self-merge, self-close issues, or modify sibling repos.
 
 **SYNC_FROM_GITHUB startup sequence:**
-1. Read target issue for the current repo.
-2. Read related PRs.
+1. Read target issue body and **comment stream** for the current repo.
+2. Read related PR bodies and **comment streams**.
 3. Read latest Program Controller / Program Agent comments on the program epic.
 4. Read Codex review threads on the target PR.
 5. Read PR body and changed files.

--- a/docs/IEF_PROGRAM_CONTROLLER_MODE.md
+++ b/docs/IEF_PROGRAM_CONTROLLER_MODE.md
@@ -1,0 +1,132 @@
+# IEF Program Controller Operating Mode
+
+This document codifies the GitHub-first control plane for IEF Program execution.
+
+## Principle
+
+**GitHub is the single control surface and durable fact source for IEF Program execution.**
+
+Chat history, session memory, and local agent state are ephemeral. They are not the source of truth. All durable instructions, status updates, blockers, and approvals must exist as GitHub issues, PRs, or comments.
+
+## Roles
+
+### Program Controller
+
+- **Responsibility:** L1 control-plane coordination.
+- **Authority:** Write issue comments, PR comments, review instructions, blocker/status comments, stale-thread judgments, `@codex review` triggers, human sign-off requests, and program issue coordination comments.
+- **Limitation:** Must not directly modify capability repo files, directly fix bugs in capability repos, directly merge PRs, directly close core issues, or modify governance/protocol/operations substantive content without explicit Human Owner approval.
+
+### Program Agent
+
+- **Responsibility:** Cross-repo orchestration and dispatch.
+- **Authority:** Read all program issues and PRs, report status, identify blockers, and request agent activation.
+- **Limitation:** Does not directly implement capability repo work. Delegates to Repo Worker Agents.
+
+### Repo Worker Agent
+
+- **Responsibility:** Single-repo implementation and delivery.
+- **Authority:** Modify files only when explicitly instructed by a GitHub issue or PR comment, create feature branches, open PRs, and reply to Codex review threads.
+- **Limitation:** Must not modify files unless a GitHub issue or PR comment explicitly requires action. Must not modify sibling repos. Must not self-merge or self-close issues.
+
+### Human Owner
+
+- **Responsibility:** High-level authorization and sign-off.
+- **Authority:** Approve operating mode changes, merge Contract-Critical PRs, close epics, and override Program Controller decisions.
+- **Limitation:** Does not perform routine implementation work.
+
+### Codex Reviewer
+
+- **Responsibility:** Automated code and document review.
+- **Authority:** Post review comments, approve PRs with reactions, and flag issues.
+- **Limitation:** Does not modify files directly. Review output is advisory unless Program Controller or Human Owner elevates it to a blocker.
+
+## Permission Boundaries
+
+| Level | Scope | Who | Examples |
+|---|---|---|---|
+| **L1** | Control-plane writes | Program Controller | Issue comments, PR comments, status updates, `@codex review` triggers, blocker declarations |
+| **L2** | Cross-repo reads and coordination | Program Agent | Read all repo issues/PRs, report cross-repo status, dispatch work to Repo Worker Agents |
+| **L3** | Single-repo implementation | Repo Worker Agent | File edits, branch creation, PR opening, Codex thread replies, test execution |
+
+**Rule:** No agent may operate above its authorized level without explicit Human Owner approval.
+
+## SYNC_FROM_GITHUB Mode
+
+Local agents (Qoder, Codex App/IDE, Claude Code, Gemini CLI, Antigravity, OpenClaw/Hermes-style agents) must run in `SYNC_FROM_GITHUB` mode.
+
+### Startup Sequence
+
+1. **Read target issue** — Identify the issue assigned to the current repo.
+2. **Read related PRs** — Identify open PRs linked to the target issue.
+3. **Read Program Controller comments** — Read the latest comments on IEF-Program#6 (or current program epic) for directives.
+4. **Read Codex review threads** — Check for unresolved review comments on the target PR.
+5. **Read PR body and changed files** — Understand the current state of delivery.
+6. **Read main branch docs/schemas/templates** — Understand existing conventions before modifying files.
+
+### Execution Rules
+
+1. **Only act when explicitly required.** If the latest GitHub comment is status/waiting/blocked, do not modify files.
+2. **Use feature branches.** Never push directly to `main`.
+3. **Only modify the current repo.** Do not touch sibling repos.
+4. **Only modify files explicitly requested.** Do not perform speculative refactoring.
+5. **Push and report.** After every modification, push to the PR branch and post a summary comment on the PR.
+6. **Reply to Codex findings.** If Codex posted review threads, reply to each one.
+7. **Trigger Codex review.** Comment `@codex review` after pushing changes.
+8. **Do not self-merge.** Wait for Program Controller or Human Owner.
+9. **Do not self-close issues.** Wait for Program Controller or Human Owner.
+10. **Do not start downstream work.** If a task requires another repo, report a blocker on the PR.
+
+### Agent-Specific Consumption Patterns
+
+| Agent | How It Consumes GitHub Control Plane |
+|---|---|
+| **Qoder CLI** | Reads issues/PRs via `gh` CLI. Responds to `SYNC_FROM_GITHUB` command. Pushes changes and comments via `gh`. |
+| **Codex App/IDE** | Reads PRs via GitHub integration. Responds to `@codex review` and `@codex address that feedback`. |
+| **Claude Code** | Reads issues/PRs via GitHub MCP or `gh` CLI. Can be instructed to sync from specific issue URLs. |
+| **Gemini CLI** | Reads issues/PRs via GitHub API or `gh` CLI. Responds to explicit issue references in prompts. |
+| **Antigravity** | Reads issues/PRs via GitHub integration. Consumes issue body and acceptance criteria as task specification. |
+| **OpenClaw / Hermes-style** | Reads issues/PRs via GitHub API. Uses issue comments as instruction stream and PR comments as delivery confirmation. |
+
+## Source of Truth Hierarchy
+
+| Priority | Source | Ephemeral? |
+|---|---|---|
+| 1 | GitHub issues | Durable |
+| 2 | GitHub PRs | Durable |
+| 3 | GitHub issue/PR comments | Durable |
+| 4 | Merged control documents (RFCs, ADRs, docs) | Durable |
+| 5 | Chat history | Ephemeral |
+| 6 | Local agent memory | Ephemeral |
+
+**Rule:** If there is a conflict between a GitHub comment and chat history, the GitHub comment wins.
+
+## Reporting Format
+
+Repo Worker Agents should produce a sync report after every `SYNC_FROM_GITHUB` cycle:
+
+```markdown
+Repo Worker Sync Report
+
+- Repo: <owner/repo>
+- Target issue: #<number> — <title>
+- Target PR: #<number> — <title> (or "None")
+- Latest head: <commit-sha>
+- Current status: <status summary>
+- Action required: <yes/no — with justification>
+- Files allowed to modify: <list or "None">
+- Files modified: <list or "None">
+- Codex status: <clean / findings pending / blocked>
+- Blockers: <list or "None">
+- Next required owner: <Program Controller / Human Owner / Repo Worker>
+```
+
+## Transition from Chat-First
+
+The previous operating mode relied on copying prompts through chat. This is deprecated because:
+
+- Chat history is not searchable by other agents.
+- Chat history is not versioned.
+- Chat history does not trigger GitHub notifications.
+- Chat history cannot be referenced in cross-repo work.
+
+All agents must transition to consuming GitHub as the primary instruction surface.

--- a/docs/IEF_PROGRAM_CONTROLLER_MODE.md
+++ b/docs/IEF_PROGRAM_CONTROLLER_MODE.md
@@ -50,33 +50,129 @@ Chat history, session memory, and local agent state are ephemeral. They are not 
 
 **Rule:** No agent may operate above its authorized level without explicit Human Owner approval.
 
-## SYNC_FROM_GITHUB Mode
+## Program Controller Execution Contract
 
-Local agents (Qoder, Codex App/IDE, Claude Code, Gemini CLI, Antigravity, OpenClaw/Hermes-style agents) must run in `SYNC_FROM_GITHUB` mode.
+The Program Controller must adhere to the following rules when directing agents.
 
-### Startup Sequence
+### Write-before-act rule
 
-1. **Read target issue** — Identify the issue assigned to the current repo.
-2. **Read related PRs** — Identify open PRs linked to the target issue.
-3. **Read Program Controller comments** — Read the latest comments on IEF-Program#6 (or current program epic) for directives.
-4. **Read Codex review threads** — Check for unresolved review comments on the target PR.
-5. **Read PR body and changed files** — Understand the current state of delivery.
-6. **Read main branch docs/schemas/templates** — Understand existing conventions before modifying files.
+- Program Controller must write durable instructions into GitHub **before** expecting agents to act.
+- Program Controller must **not** assume agents saw chat messages.
 
-### Execution Rules
+### Directive placement rule
 
-1. **Only act when explicitly required.** If the latest GitHub comment is status/waiting/blocked, do not modify files.
-2. **Use feature branches.** Never push directly to `main`.
-3. **Only modify the current repo.** Do not touch sibling repos.
-4. **Only modify files explicitly requested.** Do not perform speculative refactoring.
-5. **Push and report.** After every modification, push to the PR branch and post a summary comment on the PR.
-6. **Reply to Codex findings.** If Codex posted review threads, reply to each one.
-7. **Trigger Codex review.** Comment `@codex review` after pushing changes.
-8. **Do not self-merge.** Wait for Program Controller or Human Owner.
-9. **Do not self-close issues.** Wait for Program Controller or Human Owner.
-10. **Do not start downstream work.** If a task requires another repo, report a blocker on the PR.
+- Repo-specific work needs a directive on the **target repo issue or PR**.
+- Cross-repo sequencing should also be recorded on the **Program issue or epic**.
+- **Program-level status updates alone are not enough to activate a repo worker.** Repo-specific work must have an explicit directive on the target repo issue or PR. If a directive appears only in `IEF-Program`, repo workers may treat it as context but not as authorization to modify files.
 
-### Agent-Specific Consumption Patterns
+### Directive labels
+
+Program Controller directives should use explicit labels so agents can classify them automatically:
+
+| Label | Meaning |
+|---|---|
+| `ACTION REQUIRED` | Agent must perform work now. |
+| `BLOCKED` | Agent must stop and report why. |
+| `WAITING_HUMAN` | Agent must pause until Human Owner responds. |
+| `WAITING_CODEX` | Agent must pause until Codex review completes. |
+| `READY_FOR_PROGRAM_REVIEW` | Agent has delivered; Program Controller should review. |
+| `READY_FOR_HUMAN_SIGNOFF` | Program Controller approves; Human Owner should sign off. |
+| `UNBLOCKED` | Previous blocker is resolved; agent may resume. |
+
+### Directive completeness
+
+A directive must include enough context for the agent to act **without chat history**:
+
+- Target repo
+- Target issue or PR
+- Allowed scope (what the agent may touch)
+- Expected output (what "done" looks like)
+- PR state rule (keep draft / do not merge / do not close issue)
+
+## Standard Directive Template
+
+Program Controller comments should follow this structure when issuing actionable directives:
+
+```markdown
+## Directive
+
+- **Target repo:** owner/repo
+- **Target issue:** #N
+- **Target PR:** #M (or "None — create one")
+- **Branch:** issue-N-description
+- **Context:** <why this work is needed>
+- **Allowed scope:** <files or areas the agent may modify>
+- **Files in scope:** <explicit file list if known>
+- **Expected output:** <what the agent must deliver>
+- **State rule:** <keep draft / do not merge / do not close issue / ...>
+- **Label:** ACTION REQUIRED / BLOCKED / WAITING_HUMAN / ...
+```
+
+## Controller-Agent Interaction Loop
+
+The normal execution loop is:
+
+1. **Program Controller writes directive** to GitHub (issue or PR comment).
+2. **Agent runs `SYNC_FROM_GITHUB`.**
+3. **Agent reads latest authorized directives.**
+4. **Agent determines whether action is required.** If the latest directive is status-only, the agent reports status and stops.
+5. **Agent acts only within the stated scope.**
+6. **Agent reports back** on the issue or PR.
+7. **Program Controller reviews the report.**
+8. **Program Controller decides next state:** request changes, trigger Codex review, request human sign-off, or unblock the next repo.
+
+## SYNC_FROM_GITHUB Semantics
+
+`SYNC_FROM_GITHUB` is a **pull-based sync command**. It does not automatically authorize file changes.
+
+### What it does
+
+- Fetches the latest issue body, PR body, and comments from GitHub.
+- Rebuilds the agent's local understanding of the current state.
+
+### What it does not do
+
+- It does **not** bypass the requirement for an explicit `ACTION REQUIRED` directive.
+- It does **not** authorize the agent to modify files just because the sync succeeded.
+
+### Decision rule after sync
+
+| Latest directive | Agent action |
+|---|---|
+| `ACTION REQUIRED` | Execute within stated scope, then report. |
+| `BLOCKED` | Report blocker, stop. |
+| `WAITING_HUMAN` / `WAITING_CODEX` | Report waiting status, stop. |
+| `UNBLOCKED` | Resume previously blocked work if scope is still valid. |
+| No labeled directive | Report status only, do not modify files. |
+
+### Stale body override rule
+
+**Latest authorized GitHub control comments override stale issue or PR body text** for current operational directives. If an issue body says one thing but a recent comment says another, the comment wins.
+
+## Program Controller Pre-Flight Checklist
+
+Before telling Human Owner to start or re-run an agent, Program Controller should confirm:
+
+- [ ] The directive exists on the **target issue or PR**.
+- [ ] The directive includes **scope and expected output**.
+- [ ] The directive states **PR state rules**.
+- [ ] The directive is **discoverable by `SYNC_FROM_GITHUB`** (i.e., it is a public comment, not chat-only).
+
+## Reporting Rules
+
+### Before a PR exists
+
+If no PR has been opened yet, the agent must report progress and status **on the issue**.
+
+### After a PR exists
+
+Once a PR is opened, the agent must report **on the PR**. The issue may still receive high-level status updates, but detailed delivery summaries belong on the PR.
+
+### Transition rule
+
+When the agent creates a PR, it should post a final summary comment on the issue linking to the new PR, then continue reporting on the PR.
+
+## Agent-Specific Consumption Patterns
 
 | Agent | How It Consumes GitHub Control Plane |
 |---|---|
@@ -91,14 +187,14 @@ Local agents (Qoder, Codex App/IDE, Claude Code, Gemini CLI, Antigravity, OpenCl
 
 | Priority | Source | Ephemeral? |
 |---|---|---|
-| 1 | GitHub issues | Durable |
-| 2 | GitHub PRs | Durable |
-| 3 | GitHub issue/PR comments | Durable |
+| 1 | GitHub issue/PR comments (latest authorized) | Durable |
+| 2 | GitHub issues | Durable |
+| 3 | GitHub PRs | Durable |
 | 4 | Merged control documents (RFCs, ADRs, docs) | Durable |
 | 5 | Chat history | Ephemeral |
 | 6 | Local agent memory | Ephemeral |
 
-**Rule:** If there is a conflict between a GitHub comment and chat history, the GitHub comment wins.
+**Rule:** If there is a conflict between a GitHub comment and chat history, the GitHub comment wins. If there is a conflict between a recent comment and an older issue body, the recent comment wins.
 
 ## Reporting Format
 
@@ -130,3 +226,7 @@ The previous operating mode relied on copying prompts through chat. This is depr
 - Chat history cannot be referenced in cross-repo work.
 
 All agents must transition to consuming GitHub as the primary instruction surface.
+
+## Relationship to IEF-Protocol
+
+This document defines the **human-readable Program coordination protocol**. It is not the same as `IEF-Protocol` JSON schemas. If this interaction model later needs machine-readable messages, `IEF-Protocol` should define those objects in a separate Contract-Critical task.

--- a/docs/IEF_PROGRAM_CONTROLLER_MODE.md
+++ b/docs/IEF_PROGRAM_CONTROLLER_MODE.md
@@ -222,21 +222,17 @@ When the agent creates a PR, it should post a final summary comment on the issue
 
 ## Source of Truth Hierarchy
 
-| Priority | Source | Ephemeral? |
+| Priority | Source | Applies To |
 |---|---|---|
-| 1 | GitHub issue/PR comments (latest authorized) | Durable |
-| 2 | GitHub issues | Durable |
-| 3 | GitHub PRs | Durable |
-| 4 | Merged control documents (RFCs, ADRs, docs) | Durable |
-| 5 | Chat history | Ephemeral |
-| 6 | Local agent memory | Ephemeral |
+| 1 | Merged RFCs / ADRs / control docs | Standing policy, architecture, contracts, governance, Protocol schemas, durable decisions |
+| 2 | Latest authorized GitHub issue/PR comments | Current operational directives within active issue/PR only |
+| 3 | Issue body / PR body | Baseline scope and delivery context |
+| 4 | Chat history / local memory | Non-authoritative unless reflected in GitHub |
 
-**Rule:** If there is a conflict between a GitHub comment and chat history, the GitHub comment wins. If there is a conflict between a recent comment and an older issue body, the recent comment wins **for current operational directives only**.
-
-**Scope of precedence:**
-- Merged RFCs, ADRs, and control documents are authoritative for **standing policy, architecture, contracts, and governance**.
-- Latest authorized GitHub comments override stale issue/PR bodies **only for current operational directives** within an active issue or PR.
-- Comments must **not** override merged contracts, governance profiles, Protocol schemas, or ADR/RFC decisions.
+**Rules:**
+- Merged RFCs, ADRs, and control documents are authoritative for standing policy. Comments must not override merged contracts, governance profiles, Protocol schemas, or ADR/RFC decisions.
+- Latest authorized GitHub comments override stale issue/PR bodies only for current operational directives within an active issue or PR.
+- If there is a conflict between a GitHub comment and chat history, the GitHub comment wins.
 - If a comment needs to change standing policy, it must create or update a PR against the relevant durable document.
 
 ## Reporting Format

--- a/docs/IEF_PROGRAM_CONTROLLER_MODE.md
+++ b/docs/IEF_PROGRAM_CONTROLLER_MODE.md
@@ -14,7 +14,8 @@ Chat history, session memory, and local agent state are ephemeral. They are not 
 
 - **Responsibility:** L1 control-plane coordination.
 - **Authority:** Write issue comments, PR comments, review instructions, blocker/status comments, stale-thread judgments, `@codex review` triggers, human sign-off requests, and program issue coordination comments.
-- **Limitation:** Must not directly modify capability repo files, directly fix bugs in capability repos, directly merge PRs, directly close core issues, or modify governance/protocol/operations substantive content without explicit Human Owner approval.
+- **Limitation:** By default, must not directly modify capability repo files, directly fix bugs in capability repos, directly merge PRs, directly close core issues, or modify governance/protocol/operations substantive content.
+  - **Standing delegation exception:** Human Owner has granted conditional L3 authority under the standing delegation, but **only when** a GitHub issue or PR directive defines scope, target files, and expected output. For governance/protocol/operations core contracts, human sign-off is still required before merge. Without an explicit directive, capability repo edits remain prohibited.
 
 ### Program Agent
 
@@ -40,15 +41,17 @@ Chat history, session memory, and local agent state are ephemeral. They are not 
 - **Authority:** Post review comments, approve PRs with reactions, and flag issues.
 - **Limitation:** Does not modify files directly. Review output is advisory unless Program Controller or Human Owner elevates it to a blocker.
 
-## Permission Boundaries
+## Role Operating Boundaries
 
-| Level | Scope | Who | Examples |
-|---|---|---|---|
-| **L1** | Control-plane writes | Program Controller | Issue comments, PR comments, status updates, `@codex review` triggers, blocker declarations |
-| **L2** | Cross-repo reads and coordination | Program Agent | Read all repo issues/PRs, report cross-repo status, dispatch work to Repo Worker Agents |
-| **L3** | Single-repo implementation | Repo Worker Agent | File edits, branch creation, PR opening, Codex thread replies, test execution |
+These boundaries describe what each role is responsible for. They are independent of the numeric L0-L4 delegation levels defined in Human Owner Standing Delegation.
 
-**Rule:** No agent may operate above its authorized level without explicit Human Owner approval.
+| Role | Scope | Examples |
+|---|---|---|
+| **Program Controller** | Control-plane writes | Issue comments, PR comments, status updates, `@codex review` triggers, blocker declarations |
+| **Program Agent** | Cross-repo reads and coordination | Read all repo issues/PRs, report cross-repo status, dispatch work to Repo Worker Agents |
+| **Repo Worker Agent** | Single-repo implementation | File edits, branch creation, PR opening, Codex thread replies, test execution |
+
+**Rule:** No agent may operate outside its role boundary or delegated authority without explicit Human Owner approval.
 
 ## Human Owner Standing Delegation
 
@@ -159,7 +162,7 @@ The normal execution loop is:
 
 ### What it does
 
-- Fetches the latest issue body, PR body, and comments from GitHub.
+- Fetches the latest issue body, **issue comments**, PR body, **PR comments**, and Codex review threads from GitHub.
 - Rebuilds the agent's local understanding of the current state.
 
 ### What it does not do
@@ -175,6 +178,8 @@ The normal execution loop is:
 | `BLOCKED` | Report blocker, stop. |
 | `WAITING_HUMAN` / `WAITING_CODEX` | Report waiting status, stop. |
 | `UNBLOCKED` | Resume previously blocked work if scope is still valid. |
+| `READY_FOR_PROGRAM_REVIEW` | Agent has delivered; report delivered status and wait for Program Controller review. |
+| `READY_FOR_HUMAN_SIGNOFF` | Program Controller approves; report waiting-human status and wait for Human Owner sign-off. |
 | No labeled directive | Report status only, do not modify files. |
 
 ### Stale body override rule
@@ -226,7 +231,13 @@ When the agent creates a PR, it should post a final summary comment on the issue
 | 5 | Chat history | Ephemeral |
 | 6 | Local agent memory | Ephemeral |
 
-**Rule:** If there is a conflict between a GitHub comment and chat history, the GitHub comment wins. If there is a conflict between a recent comment and an older issue body, the recent comment wins.
+**Rule:** If there is a conflict between a GitHub comment and chat history, the GitHub comment wins. If there is a conflict between a recent comment and an older issue body, the recent comment wins **for current operational directives only**.
+
+**Scope of precedence:**
+- Merged RFCs, ADRs, and control documents are authoritative for **standing policy, architecture, contracts, and governance**.
+- Latest authorized GitHub comments override stale issue/PR bodies **only for current operational directives** within an active issue or PR.
+- Comments must **not** override merged contracts, governance profiles, Protocol schemas, or ADR/RFC decisions.
+- If a comment needs to change standing policy, it must create or update a PR against the relevant durable document.
 
 ## Reporting Format
 

--- a/docs/IEF_PROGRAM_CONTROLLER_MODE.md
+++ b/docs/IEF_PROGRAM_CONTROLLER_MODE.md
@@ -50,6 +50,38 @@ Chat history, session memory, and local agent state are ephemeral. They are not 
 
 **Rule:** No agent may operate above its authorized level without explicit Human Owner approval.
 
+## Human Owner Standing Delegation
+
+Human Owner may grant standing delegation to the Program Controller. This delegation is recorded as a durable GitHub comment and remains active until revoked or superseded by a later Human Owner comment.
+
+**Platform limitation:** Platform and tool-level confirmation prompts may still appear and cannot be bypassed by this delegation. The delegation governs IEF organizational authority, not local security controls.
+
+### Delegated levels
+
+| Level | Scope | Default | Conditions |
+|---|---|---|---|
+| **L0** | Read across all everwork-ai IEF repositories | Allowed | No additional authorization required. |
+| **L1** | Control-plane writes | Allowed by default | Issue comments, PR comments, review instructions, blocker/status comments, stale-thread judgments, `@codex review` triggers, human sign-off requests, downstream unblock/block directives. |
+| **L2** | IEF-Program documentation changes | Allowed via branch + PR | Program Controller may create and update PRs, but must not merge without human sign-off unless explicitly authorized. |
+| **L3** | Capability repo content changes | Allowed only with explicit directive | Requires a GitHub issue or PR directive defining scope, target files, and expected output. Program Controller may create branches, push commits, open/update PRs, and reply to review threads. Must not directly merge or close core issues without human approval. |
+| **L4** | Merge / close actions | Require explicit sign-off | Human Owner sign-off required unless the PR falls under a separately approved auto-merge rule. |
+
+### Prohibited actions
+
+Even under standing delegation, the Program Controller must not:
+
+- Delete repositories
+- Change organization permissions
+- Change secrets, tokens, or billing settings
+- Force-push
+- Change branch protection rules
+- Perform production deployment
+- Merge governance, protocol, or operations core contracts without human sign-off
+
+### Revocation
+
+Human Owner may revoke or supersede this delegation at any time by posting a new comment on the active program epic or the PR where the delegation was recorded.
+
 ## Program Controller Execution Contract
 
 The Program Controller must adhere to the following rules when directing agents.


### PR DESCRIPTION
## Summary

This PR codifies the GitHub-first control plane for IEF Program execution, as required by issue #7.

## Linked Issue

Closes #7

## Files Created/Updated

### Created
- `docs/IEF_PROGRAM_CONTROLLER_MODE.md` — Durable program document describing the GitHub-first control plane

### Updated
- `docs/IEF_GITHUB_WORKFLOW.md` — Added "Agent Operating Mode" section referencing the new document and defining the SYNC_FROM_GITHUB startup sequence
- `README.md` — Added "Program Controller Mode" to the control documents index

## Governance Profile

Contract-Critical

## Evidence

- All internal links render correctly in GitHub preview
- Document structure follows existing IEF docs conventions
- No capability repo content is modified

## Risks

- This is a new control document. If the operating mode is rejected, the document can be removed in a follow-up PR.
- Agent consumption patterns are descriptive (current-state) rather than normative (prescriptive) for external tools outside IEF direct control.

## Rollback Plan

- Revert this PR to remove the new document and index references
- Follow-up PR can amend the document if role definitions or boundary rules need refinement